### PR TITLE
Include all RFC1918 address space in mynetworks

### DIFF
--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -20,7 +20,7 @@ postconf "relayhost = ${TX_SMTP_RELAY_HOST}" || exit 1
 postconf "myhostname = ${TX_SMTP_RELAY_MYHOSTNAME}" || exit 1
 
 # Override what you want here. The 10. network is for kubernetes
-postconf 'mynetworks = 10.0.0.0/8,127.0.0.0/8,172.17.0.0/16' || exit 1
+postconf 'mynetworks = 10.0.0.0/8,127.0.0.0/8,172.16.0.0/12,192.168.0.0/16' || exit 1
 
 # http://www.postfix.org/COMPATIBILITY_README.html#smtputf8_enable
 postconf 'smtputf8_enable = no' || exit 1


### PR DESCRIPTION
Include all RFC1918 address space in `mynetworks`. This is useful to run a containerised SMTP relay for a local LAN segment