### PR TITLE
Security: update alpine version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ We needed a simple docker image that can be configured with env vars. Also, the 
 Run on docker
 ```
 docker run --rm -it -p 2525:25 \
-	-e TX_SMTP_RELAY_HOST="[smtp.sendgrid.net]:587" \
+	-e TX_SMTP_RELAY_HOST="smtp.sendgrid.net" \
+	-e TX_SMTP_RELAY_PORT=25 \
 	-e TX_SMTP_RELAY_MYHOSTNAME=tx-smtp-relay.yourhost.com \
 	-e TX_SMTP_RELAY_USERNAME=username \
 	-e TX_SMTP_RELAY_PASSWORD=password \
 	applariat/tx-smtp-relay
 
 ```
+
+Note that all parameters except TX_SMTP_RELAY_PORT are required.  The default value for the port is 25.
+
 Send a test message
 <pre>
 <b>telnet localhost 2525</b>

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.14.3
 MAINTAINER Chris Dornsife <chris@applariat.com>
 
 RUN apk add --no-cache ca-certificates postfix rsyslog supervisor \

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.3
+FROM alpine:3.16
 MAINTAINER Chris Dornsife <chris@applariat.com>
 
 RUN apk add --no-cache ca-certificates postfix rsyslog supervisor \

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.4
 MAINTAINER Chris Dornsife <chris@applariat.com>
 
-RUN apk add --no-cache postfix rsyslog supervisor \
+RUN apk add --no-cache ca-certificates postfix rsyslog supervisor \
     && /usr/bin/newaliases
 
 COPY . /

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache postfix rsyslog supervisor \
 
 COPY . /
 
-EXPOSE 587
+EXPOSE 25
 
 ENTRYPOINT [ "/tx-smtp-relay.sh" ]
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache postfix rsyslog supervisor \
 
 COPY . /
 
-EXPOSE 25
+EXPOSE 587
 
 ENTRYPOINT [ "/tx-smtp-relay.sh" ]
 

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -18,7 +18,7 @@ postmap /etc/postfix/sasl_passwd || exit 1
 rm /etc/postfix/sasl_passwd || exit 1
 
 postconf 'smtp_sasl_auth_enable = yes' || exit 1
-postconf 'smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd' || exit 1
+postconf 'smtp_sasl_password_maps = lmdb:/etc/postfix/sasl_passwd' || exit 1
 postconf 'smtp_sasl_security_options =' || exit 1
 
 # These are required.

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -5,6 +5,12 @@ TX_SMTP_RELAY_MYHOSTNAME=${TX_SMTP_RELAY_MYHOSTNAME?Missing env var TX_SMTP_RELA
 TX_SMTP_RELAY_USERNAME=${TX_SMTP_RELAY_USERNAME?Missing env var TX_SMTP_RELAY_USERNAME}
 TX_SMTP_RELAY_PASSWORD=${TX_SMTP_RELAY_PASSWORD?Missing env var TX_SMTP_RELAY_PASSWORD}
 
+# Port is set to 25 by default unless specifically set
+TX_SMTP_RELAY_PORT=${TX_SMTP_RELAY_PORT:-25}
+
+# Put host/port into postconf format
+TX_SMTP_RELAY_HOST="[${TX_SMTP_RELAY_HOST}]:${TX_SMTP_RELAY_PORT}"
+
 
 # handle sasl
 echo "${TX_SMTP_RELAY_HOST} ${TX_SMTP_RELAY_USERNAME}:${TX_SMTP_RELAY_PASSWORD}" > /etc/postfix/sasl_passwd || exit 1

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -28,4 +28,10 @@ postconf 'smtputf8_enable = no' || exit 1
 # This makes sure the message id is set. If this is set to no dkim=fail will happen.
 postconf 'always_add_missing_headers = yes' || exit 1
 
+# TLS
+postconf "smtp_use_tls = yes" || exit 1
+postconf "smtp_tls_security_level = encrypt" || exit 1
+postconf "smtp_tls_note_starttls_offer = yes" || exit 1
+postconf -e 'smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt' || exit 1
+
 /usr/bin/supervisord -n

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -5,12 +5,6 @@ TX_SMTP_RELAY_MYHOSTNAME=${TX_SMTP_RELAY_MYHOSTNAME?Missing env var TX_SMTP_RELA
 TX_SMTP_RELAY_USERNAME=${TX_SMTP_RELAY_USERNAME?Missing env var TX_SMTP_RELAY_USERNAME}
 TX_SMTP_RELAY_PASSWORD=${TX_SMTP_RELAY_PASSWORD?Missing env var TX_SMTP_RELAY_PASSWORD}
 
-# configure postfix to silently drop emails to @sink.sendgrid.net
-echo '/^.*sink\.sendgrid\.net/ DISCARD' > /etc/postfix/header_checks_sg || exit 1
-postconf 'header_checks = regexp:/etc/postfix/header_checks_sg' || exit 1
-
-# enable port 587
-postconf -M submission/inet="submission inet n - n - - smtpd"
 
 # handle sasl
 echo "${TX_SMTP_RELAY_HOST} ${TX_SMTP_RELAY_USERNAME}:${TX_SMTP_RELAY_PASSWORD}" > /etc/postfix/sasl_passwd || exit 1

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -20,7 +20,7 @@ postconf "relayhost = ${TX_SMTP_RELAY_HOST}" || exit 1
 postconf "myhostname = ${TX_SMTP_RELAY_MYHOSTNAME}" || exit 1
 
 # Override what you want here. The 10. network is for kubernetes
-postconf 'mynetworks = 10.0.0.0/8,127.0.0.0/8,172.17.0.0/16' || exit 1
+postconf 'mynetworks = 10.0.0.0/8,127.0.0.0/8,172.17.0.0/16,100.64.0.0/10' || exit 1
 
 # http://www.postfix.org/COMPATIBILITY_README.html#smtputf8_enable
 postconf 'smtputf8_enable = no' || exit 1

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -5,6 +5,9 @@ TX_SMTP_RELAY_MYHOSTNAME=${TX_SMTP_RELAY_MYHOSTNAME?Missing env var TX_SMTP_RELA
 TX_SMTP_RELAY_USERNAME=${TX_SMTP_RELAY_USERNAME?Missing env var TX_SMTP_RELAY_USERNAME}
 TX_SMTP_RELAY_PASSWORD=${TX_SMTP_RELAY_PASSWORD?Missing env var TX_SMTP_RELAY_PASSWORD}
 
+# configure postfix to silently drop emails to @sink.sendgrid.net
+echo '/^.*sink\.sendgrid\.net/ DISCARD' > /etc/postfix/header_checks_sg || exit 1
+postconf 'header_checks = regexp:/etc/postfix/header_checks_sg' || exit 1
 
 # handle sasl
 echo "${TX_SMTP_RELAY_HOST} ${TX_SMTP_RELAY_USERNAME}:${TX_SMTP_RELAY_PASSWORD}" > /etc/postfix/sasl_passwd || exit 1

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -9,6 +9,9 @@ TX_SMTP_RELAY_PASSWORD=${TX_SMTP_RELAY_PASSWORD?Missing env var TX_SMTP_RELAY_PA
 echo '/^.*sink\.sendgrid\.net/ DISCARD' > /etc/postfix/header_checks_sg || exit 1
 postconf 'header_checks = regexp:/etc/postfix/header_checks_sg' || exit 1
 
+# enable port 587
+postconf -M submission/inet="submission inet n - n - - smtpd"
+
 # handle sasl
 echo "${TX_SMTP_RELAY_HOST} ${TX_SMTP_RELAY_USERNAME}:${TX_SMTP_RELAY_PASSWORD}" > /etc/postfix/sasl_passwd || exit 1
 postmap /etc/postfix/sasl_passwd || exit 1


### PR DESCRIPTION
This PR updates the base alpine version to 3.16 to address several known vulnerabilities in alpine 3.14. There are no known exploits of the vulnerabilities but they exist nonetheless.

I haven't tested this but I can't see this PR being especially problematic.